### PR TITLE
Update 01-policy-require-mtls.yaml

### DIFF
--- a/demo/01-policy-require-mtls.yaml
+++ b/demo/01-policy-require-mtls.yaml
@@ -1,8 +1,8 @@
-apiVersion: authentication.istio.io/v1alpha1
-kind: Policy
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: default
   namespace: servicemesh-demo
 spec:
-  peers:
-  - mtls: {}
+  mtls:
+    mode: STRICT


### PR DESCRIPTION
Since istio 1.6 "PeerAuthentication" must be used instead of "Policy"